### PR TITLE
Fix order_by() not being wrapped by understand_money()

### DIFF
--- a/djmoney/models/managers.py
+++ b/djmoney/models/managers.py
@@ -206,7 +206,7 @@ def understands_money(func):
     return wrapper
 
 
-RELEVANT_QUERYSET_METHODS = ("distinct", "get", "get_or_create", "filter", "exclude", "update")
+RELEVANT_QUERYSET_METHODS = ("distinct", "get", "get_or_create", "filter", "exclude", "update", "order_by")
 EXPAND_EXCLUSIONS = {"get_or_create": ("defaults",)}
 
 


### PR DESCRIPTION
This is probably related to https://github.com/django-money/django-money/issues/99, but
money_manager didn't work correctly with order_by. This fails with both custom
money_manager() and the automatically generated manager.

# Minimal test case

## tests.py
   
    from django.test import TestCase
   
    from djmoney.money import Money
    from chaining.models import Question
   
   
    class QuestionTest(TestCase):
        def test_prize(self):
            question_aud = Question.objects.create(prize=Money(10, 'AUD'))
            question_usd = Question.objects.create(prize=Money(10, 'USD'))
   
            # passes as expected
            self.assertQuerysetEqual(
                Question.objects.filter(prize=Money(10, 'AUD')),
                ['<Question: Q#1 - A$10.00>'],
            )
   
            # however, order_by didn't work correctly
            self.assertQuerysetEqual(
                Question.objects.order_by('id').filter(prize=Money(10, 'AUD')),
                ['<Question: Q#1 - A$10.00>'],
                # actual value: ['<Question: Q#1 - A$10.00>', '<Question: Q#2 - $10.00>']
            )


## models.py

    from django.db import models
    from djmoney.models.fields import MoneyField
   
   
    class Question(models.Model):
        prize = MoneyField(decimal_places=2, max_digits=10)
   
        def __str__(self):
            return 'Q#{} - {}'.format(self.pk, self.prize)